### PR TITLE
Change status from project on calendar to subproject

### DIFF
--- a/html/admin/assets/widgets/calendar.twig
+++ b/html/admin/assets/widgets/calendar.twig
@@ -84,7 +84,7 @@
                         {%  for subproject in project.subProjects %}
                             {% if subproject.projects_dates_use_start != null and subproject.projects_dates_use_end != null %}
                                 {
-                                    title          : "↳ [{{ STATUSES[project.projects_status]["name"]|escape("js") }}] {{ subproject.clients_name ? subproject.clients_name|escape("js") ~ " - " }}{{ subproject.projects_name|escape("js") }}",
+                                    title          : "↳ [{{ STATUSES[subproject.projects_status]["name"]|escape("js") }}] {{ subproject.clients_name ? subproject.clients_name|escape("js") ~ " - " }}{{ subproject.projects_name|escape("js") }}",
                                     start          : {{ subproject.projects_dates_use_start|date('U') }}*1000,
                                     end            : {{ subproject.projects_dates_use_end|date('U') }}*1000,
                                     url            : '{{CONFIG.ROOTURL}}/project/?id={{ subproject.projects_id }}',


### PR DESCRIPTION
Updated the calendar widget to show the correct status for subprojects.

Did not update documentation for bug fix.
## Checklist:

*Add any outstanding items to this checklist, but don't delete the default options*

- [ ] Updates documentation
- [x] Tested locally